### PR TITLE
Add `connection_types` to `get_provider_info()` entrypoint

### DIFF
--- a/duckdb_provider/__init__.py
+++ b/duckdb_provider/__init__.py
@@ -4,5 +4,8 @@ def get_provider_info():
         "name": "DuckDB Airflow Provider",
         "description": "DuckDB (duckdb.org) provider for Apache Airflow",
         "hook-class-names": ["duckdb_provider.hooks.duckdb_hook.DuckDBHook"],
+        "connection-types": [
+            {"connection-type": "duckdb", "hook-class-name": "duckdb_provider.hooks.duckdb_hook.DuckDBHook"}
+        ],
         "versions": ["0.0.2"],
     }


### PR DESCRIPTION
As of Airflow 2.2, the `hook-class-names` property has been deprecated for use in the `get_provider_info()` entrypoint in provider packages in favor of `connection-types`. However, if the provider needs to support Airflow versions <2.2 (which this provider does) than both `hook-class-names` _and_ `connection-types` should exist in the entrypoint.

Also, users will see this warning in webserver logs due to missing `connection-types` on Airflow versions 2.2+:
```
DeprecationWarning: The provider airflow-provider-duckdb uses `hook-class-names` property in provider-info and has no `connection-types` one. The 'hook-class-names' property has been deprecated in favour of 'connection-types' in Airflow 2.2. Use **both** in case you want to have backwards compatibility with Airflow < 2.2
```