### PR TITLE
Add token field for MotherDuck in DuckDB connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,29 @@ pip install airflow-provider-duckdb
 
 The connection type is `duckdb`. It supports setting the following parameters:
 
-- `host` (optional): Path to local file or MotherDuck database (leave blank for in-memory database)
-- `password` (optional): MotherDuck Service token (leave blank for local database)
+| Airflow field name | Airflow UI label            | Description                                                                |
+| ------------------ | --------------------------- | -------------------------------------------------------------------------- |
+| `host`             | Path to local database file | Path to local file. Leave blank (with no password) for in-memory database. |
+| `schema`           | MotherDuck database name    | Name of the MotherDuck database. Leave blank for default.                  |
+| `password`         | MotherDuck Service token    | MotherDuck Service token. Leave blank for local database.                  |
 
 These have been relabeled in the Airflow UI for clarity.
 
 For example, if you want to connect to a local file:
 
-- `host`: `/path/to/file.db`
-- `password`: (leave blank)
+| Airflow field name | Airflow UI label            | Value              |
+| ------------------ | --------------------------- | ------------------ |
+| `host`             | Path to local database file | `/path/to/file.db` |
+| `schema`           | MotherDuck database name    | (leave blank)      |
+| `password`         | MotherDuck Service token    | (leave blank)      |
 
 If you want to connect to a MotherDuck database:
 
-- `host`: `<YOUR_DB_NAME>`
-- `password`: `<YOUR_MOTHERDUCK_SERVICE_TOKEN>`
+| Airflow field name | Airflow UI label            | Value                                        |
+| ------------------ | --------------------------- | -------------------------------------------- |
+| `host`             | Path to local database file | (leave blank)                                |
+| `schema`           | MotherDuck database name    | `<YOUR_DB_NAME>`, or leave blank for default |
+| `password`         | MotherDuck Service token    | `<YOUR_SERVICE_TOKEN>`                       |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A DuckDB provider for Airflow. This provider exposes a hook/connection that returns a DuckDB connection.
 
+This works for either local or MotherDuck connections.
+
 ## Installation
 
 ```bash
@@ -12,12 +14,20 @@ pip install airflow-provider-duckdb
 
 The connection type is `duckdb`. It supports setting the following parameters:
 
-- `file` (optional): The path to the DuckDB database file. If not set, operations will be done in-memory.
+- `host` (optional): Path to local file or MotherDuck database (leave blank for in-memory database)
+- `password` (optional): MotherDuck Service token (leave blank for local database)
 
-Example connection strings:
+These have been relabeled in the Airflow UI for clarity.
 
-- `duckdb://:memory:`
-- `duckdb:///tmp/duckdb.db`
+For example, if you want to connect to a local file:
+
+- `host`: `/path/to/file.db`
+- `password`: (leave blank)
+
+If you want to connect to a MotherDuck database:
+
+- `host`: `<YOUR_DB_NAME>`
+- `password`: `<YOUR_MOTHERDUCK_SERVICE_TOKEN>`
 
 ## Usage
 

--- a/duckdb_provider/hooks/duckdb_hook.py
+++ b/duckdb_provider/hooks/duckdb_hook.py
@@ -47,7 +47,7 @@ class DuckDBHook(DbApiHook):
 
         # if a token was given, return a MotherDuck URI
         if airflow_conn.password:
-            return "motherduck:///" + airflow_conn.host
+            return "motherduck:///" + airflow_conn.host + "?token=" + airflow_conn.password
 
         # if we don't have a host, assume we're using an in-memory database
         if not airflow_conn.host:

--- a/duckdb_provider/hooks/duckdb_hook.py
+++ b/duckdb_provider/hooks/duckdb_hook.py
@@ -47,7 +47,7 @@ class DuckDBHook(DbApiHook):
 
         # if a token was given, return a MotherDuck URI
         if airflow_conn.password:
-            return "motherduck:///" + airflow_conn.host + "?token=" + airflow_conn.password
+            return "motherduck:" + airflow_conn.host + "?token=" + airflow_conn.password
 
         # if we don't have a host, assume we're using an in-memory database
         if not airflow_conn.host:

--- a/duckdb_provider/hooks/duckdb_hook.py
+++ b/duckdb_provider/hooks/duckdb_hook.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 import duckdb
 
+from airflow.exceptions import AirflowException
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 
@@ -15,54 +16,60 @@ class DuckDBHook(DbApiHook):
     hook_name = "DuckDB"
     placeholder = "?"
 
+    def __init__(self, *args, **kwargs):
+        "Validates the connection arguments"
+        super().__init__(*args, **kwargs)
+
+        if self.is_motherduck and self.is_local:
+            raise AirflowException(
+                "You cannot set both host and schema! If you're connecting to a local file, set host to the path to the file. If you're connecting to a MotherDuck instance, set schema to the database name."
+            )
+
     def get_conn(self) -> duckdb.DuckDBPyConnection:
         """Returns a duckdb connection object"""
-        # get the conn_id from the hook
         conn_id = getattr(self, self.conn_name_attr)
-
-        # get the airflow connection object with config
         airflow_conn = self.get_connection(conn_id)
 
-        # define the connection string based on the specified service
-        if airflow_conn.host == "motherduck":
-            if not airflow_conn.password:
-                raise ValueError("Connecting to MotherDuck requires a token!")
-            else:
-                connection_string = f"motherduck:{airflow_conn.schema}?token={airflow_conn.password}"
-        elif airflow_conn.host == "duckdb":
-            connection_string = f"{airflow_conn.schema}"
-        else:
-            raise ValueError("Service name must be 'motherduck' or 'duckdb'")
-        
-        print(f"Connecting to: {connection_string} ...")
+        if self.is_motherduck:
+            db_name = airflow_conn.schema or ""
+            return duckdb.connect(
+                f"md:{db_name}?motherduck_token={airflow_conn.password}"
+            )
 
-        return duckdb.connect(connection_string)
+        if self.is_local:
+            return duckdb.connect(airflow_conn.host)
+
+        return duckdb.connect(":memory:")
 
     def get_uri(self) -> str:
         """Override DbApiHook get_uri method for get_sqlalchemy_engine()"""
-
-        # get the conn_id from the hook
         conn_id = getattr(self, self.conn_name_attr)
-
-        # get the airflow connection object with config
         airflow_conn = self.get_connection(conn_id)
 
-        # define the connection string based on the specified service
-        if airflow_conn.host == "motherduck":
-            if not airflow_conn.password:
-                raise ValueError("Connecting to MotherDuck requires a token!")
-            else:
-                connection_string = f"motherduck:{airflow_conn.schema}?motherduck_token={airflow_conn.password}"
-        elif airflow_conn.host == "duckdb":
-            connection_string = f"{airflow_conn.schema}"
-        else:
-            raise ValueError("Service name must be 'motherduck' or 'duckdb'")
-        
-        print(f"Connecting to: {connection_string} ...")
+        if self.is_motherduck:
+            db_name = airflow_conn.schema or ""
+            return f"duckdb:///md:{db_name}?motherduck_token={airflow_conn.password}"
 
-        # return the URI for SQLAlchemy
-        return f"duckdb:///{connection_string}"
+        if self.is_local:
+            return f"duckdb:///{airflow_conn.host}"
 
+        return "duckdb:///:memory:"
+
+    @property
+    def is_motherduck(self) -> bool:
+        "Returns True if the connection is to a MotherDuck instance"
+        conn_id = getattr(self, self.conn_name_attr)
+        airflow_conn = self.get_connection(conn_id)
+
+        return bool(airflow_conn.password)
+
+    @property
+    def is_local(self) -> bool:
+        "Returns True if the connection is to a local file"
+        conn_id = getattr(self, self.conn_name_attr)
+        airflow_conn = self.get_connection(conn_id)
+
+        return bool(airflow_conn.host)
 
     @staticmethod
     def get_ui_field_behaviour() -> Dict:
@@ -70,8 +77,8 @@ class DuckDBHook(DbApiHook):
         return {
             "hidden_fields": ["login", "port", "extra"],
             "relabeling": {
-                "host": "Service name ('motherduck' or 'duckdb')",
-                "schema": "Filepath to a local DuckDB database or name of a MotherDuck table (leave blank for in-memory database)",
-                "password": "MotherDuck Service token (leave blank for local database)"
+                "host": "Path to local database file",
+                "schema": "MotherDuck database name",
+                "password": "MotherDuck Service token",
             },
         }

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="airflow-provider-duckdb",
-    version="0.0.2",
+    version="0.2.0",
     description="DuckDB (duckdb.org) provider for Apache Airflow",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Hi

I am testing MotherDucks alpha and was thinking it would be nice to have a Token field to add the token to the connection and also a motherduck specific URI string. This is my attempt at adding this in, embarrassingly I don't know how to build a provider locally so I don't know how to test this 😅 

I have tested the connection strings in a script:

- `duckdb.connect("motherduck:?token={MOTHERDUCK_TOKEN}")` this connects to the MotherDuck default db
- `duckdb.connect("motherduck:my_named_db?token={MOTHERDUCK_TOKEN}"` this connects to `my_named_db`
- `duckdb.connect("")` uses an in memory db
- `duckdb.connect("hello")` creates/uses a db called hello in the working dir
